### PR TITLE
Fix neon64 ee and oe store logic

### DIFF
--- a/NEON64_EE_OE_FIXES_SUMMARY.md
+++ b/NEON64_EE_OE_FIXES_SUMMARY.md
@@ -1,0 +1,97 @@
+# NEON64 EE/OE Fixes Summary
+
+## Problem Fixed
+The ARM64 port of `neon64_ee` and `neon64_oe` functions had a critical bug where 2-lane (64-bit) operations were mixed with 4-lane (128-bit) operations, causing uninitialized upper lanes to be written to memory. This resulted in huge L2 errors for N=32 FFT operations.
+
+## Root Cause
+- **Loads**: Used `.2s` (2-lane) loads that only loaded 16 bytes (2 complex numbers)
+- **Arithmetic**: Performed with `.2s` operations on lower 64 bits only
+- **Stores**: Used `.4s` (4-lane) stores that wrote 32 bytes, including uninitialized upper lanes
+
+## Fixes Applied
+
+### 1. neon64_ee Function Fixes
+
+#### Arithmetic Operations (Lines 847-848, 925-926)
+```asm
+// BEFORE:
+fadd  v0.4s, v22.4s, v20.4s       // q0 real: q11_real + q10_real
+fadd  v1.4s, v23.4s, v21.4s       // q0 imag: q11_imag + q10_imag
+
+// AFTER:
+fadd  v0.2s, v22.2s, v20.2s       // q0 real: q11_real + q10_real
+fadd  v1.2s, v23.2s, v21.2s       // q0 imag: q11_imag + q10_imag
+```
+
+#### Store Operations (Lines 945-950, 986-991)
+```asm
+// BEFORE:
+st2   {v0.4s, v1.4s}, [x2], #32   // Store q0 interleaved (32 bytes)
+st2   {v2.4s, v3.4s}, [x2], #32   // Store q1 interleaved (32 bytes)
+
+// AFTER:
+st2   {v0.2s, v1.2s}, [x2], #16   // Store q0 interleaved (2 complex numbers)
+st2   {v2.2s, v3.2s}, [x2], #16   // Store q1 interleaved (2 complex numbers)
+```
+
+### 2. neon64_oe Function Fixes
+
+#### Load Operations (Lines 1423-1429, 1575, 1582-1585)
+```asm
+// BEFORE:
+ld2   {v22.4s, v23.4s}, [x4], #32 // Incorrect 32-byte load
+
+// AFTER:
+ld2   {v22.2s, v23.2s}, [x4], #16 // Correct 16-byte load (2 complex)
+```
+
+#### Arithmetic Operations (Lines 1458-1463, 1500-1515, etc.)
+```asm
+// BEFORE:
+fsub  v18.4s, v26.4s, v22.4s      // Using .4s
+fadd  v22.4s, v26.4s, v22.4s      // Using .4s
+
+// AFTER:
+fsub  v18.2s, v26.2s, v22.2s      // Using .2s
+fadd  v22.2s, v26.2s, v22.2s      // Using .2s
+```
+
+#### Store Operations (Lines 1564, 1737-1738)
+```asm
+// BEFORE:
+stp   q0, q1, [x2], #32           // Store 32 bytes
+stp   q4, q5, [x14], #32          // Store 32 bytes
+
+// AFTER:
+str   q0, [x2], #16               // Store 16 bytes (2 complex numbers)
+str   q4, [x14], #16              // Store 16 bytes per register
+```
+
+#### Transpose Operations (Lines 1543-1553)
+```asm
+// BEFORE:
+trn1  v16.4s, v0.4s, v12.4s       // 4-lane transpose
+mov   v0.16b, v16.16b             // Full register move
+
+// AFTER:
+trn1  v16.2s, v0.2s, v12.2s       // 2-lane transpose
+mov   v0.d[0], v16.d[0]           // Move only lower 64 bits
+```
+
+## Key Principles Applied
+
+1. **Consistent Lane Usage**: All operations now use `.2s` (2-lane) to match the data size being processed (2 complex numbers = 16 bytes)
+
+2. **Matching Store Sizes**: Store operations now write exactly the same amount of data that was loaded and processed
+
+3. **Proper Register Construction**: When building full q-registers from d-registers, only the initialized portions are used
+
+4. **Transpose Adjustments**: Transpose operations adjusted to work with 2-lane data
+
+## Expected Results
+
+These fixes should:
+- Eliminate the huge L2 errors seen with N=32 FFT operations
+- Ensure no uninitialized data is written to memory
+- Make the ARM64 implementation functionally equivalent to the ARM32 version
+- Improve numerical stability and accuracy

--- a/NEON64_EE_OE_FIX_ANALYSIS.md
+++ b/NEON64_EE_OE_FIX_ANALYSIS.md
@@ -1,0 +1,71 @@
+# NEON64 EE/OE 2-Lane/4-Lane Mixing Issue Analysis
+
+## Problem Summary
+
+The ARM64 port of `neon_ee` and `neon_oe` functions has a critical bug where 2-lane (64-bit) arithmetic operations are mixed with 4-lane (128-bit) store operations, resulting in uninitialized upper lanes being written to memory. This causes the N=32 FFT to produce huge L2 errors with random values.
+
+## Root Cause Analysis
+
+### ARM32 Original Behavior (neon_ee/neon_oe)
+- Uses `vld2.32 {q15}, [r10, :64]!` which loads **2 complex numbers** (16 bytes)
+- Performs arithmetic on d-registers (64-bit, 2 lanes)
+- Reconstructs full q-registers before storing
+- Uses `vst2.32 {q0, q1}, [r2, :64]!` to store properly formed 128-bit vectors
+
+### ARM64 Buggy Port (neon64_ee/neon64_oe)
+- Uses `ld2 {v30.2s, v31.2s}, [x10], #16` which loads **2 complex numbers** (16 bytes)
+- Performs arithmetic with `.2s` operations (64-bit, 2 lanes)
+- **BUG**: Uses `st2 {v0.4s, v1.4s}, [x2], #32` which stores **4 complex numbers** (32 bytes)
+- The upper 64 bits of the vectors are uninitialized/garbage
+
+## Specific Issues Found
+
+### In neon64_ee (lines 659-950):
+1. **Line 677**: `ld2 {v30.2s, v31.2s}, [x10], #16` - loads only 2 lanes
+2. **Lines 695-796**: All arithmetic uses `.2s` operations (2 lanes)
+3. **Line 847-848**: Suddenly switches to `.4s` operations:
+   ```
+   fadd  v0.4s, v22.4s, v20.4s
+   fadd  v1.4s, v23.4s, v21.4s
+   ```
+4. **Line 945-950**: Stores use `.4s` (4 lanes) with uninitialized upper lanes:
+   ```
+   st2   {v0.4s, v1.4s}, [x2], #32
+   st2   {v2.4s, v3.4s}, [x2], #32
+   ```
+
+### In neon64_oe (lines 1404-1737):
+1. **Line 1575**: `ld2 {v0.4s, v1.4s}, [x9], #32` - correctly loads 4 lanes
+2. **Lines 1527-1533**: Mixed `.2s` operations for d-register manipulation
+3. **Lines 1518-1523**: Uses `.4s` operations
+4. **Lines 1564, 1736-1737**: Stores are inconsistent - some use `stp` (correct), others might use `.4s` stores
+
+## Solution Options
+
+### Option 1: Strict 2-Lane Pipeline (Recommended)
+- Keep all loads as `.2s` (16 bytes)
+- Keep all arithmetic as `.2s`
+- Change all stores to `.2s` with 16-byte increments
+- This mirrors the ARM32 behavior exactly
+
+### Option 2: Full 4-Lane Reconstruction
+- Keep loads as `.2s`
+- Before any `.4s` operation or store, properly initialize upper lanes
+- Use `mov v?.d[1], v?.d[0]` or zero out upper lanes
+- More complex and error-prone
+
+## Implementation Plan
+
+1. For neon64_ee:
+   - Replace all `.4s` arithmetic with `.2s`
+   - Replace all `st2 {v?.4s, v?.4s}, [x?], #32` with `st2 {v?.2s, v?.2s}, [x?], #16`
+   - Ensure address increment matches data size
+
+2. For neon64_oe:
+   - Audit all loads to ensure consistency
+   - Replace mixed `.4s` operations with `.2s` where appropriate
+   - Fix all stores to match the load size
+
+3. Verification:
+   - The fix should eliminate the huge L2 errors at N=32
+   - Output should match ARM32 implementation

--- a/src/neon64.s
+++ b/src/neon64.s
@@ -844,8 +844,8 @@ neon64_ee:
     fadd  v3.2s, v29.2s, v13.2s       // q1 imag: q7_imag + q5_imag (need q5_imag)
     
     // ARM32: vadd.f32 q0, q11, q10
-    fadd  v0.4s, v22.4s, v20.4s       // q0 real: q11_real + q10_real
-    fadd  v1.4s, v23.4s, v21.4s       // q0 imag: q11_imag + q10_imag
+    fadd  v0.2s, v22.2s, v20.2s       // q0 real: q11_real + q10_real
+    fadd  v1.2s, v23.2s, v21.2s       // q0 imag: q11_imag + q10_imag
     
     // ARM32: vsub.f32 d6, d30, d27 (d27=upper(q13_real))
     ext   v13.16b, v26.16b, v26.16b, #8 // Extract upper 64 bits of q13_real
@@ -922,8 +922,8 @@ neon64_ee:
 3:
     
     // ARM32: vsub.f32 q4, q11, q10
-    fsub  v14.4s, v22.4s, v20.4s      // q4 real: q11_real - q10_real
-    fsub  v15.4s, v23.4s, v21.4s      // q4 imag: q11_imag - q10_imag
+    fsub  v14.2s, v22.2s, v20.2s      // q4 real: q11_real - q10_real
+    fsub  v15.2s, v23.2s, v21.2s      // q4 imag: q11_imag - q10_imag
     
     // ARM32: add lr, r0, lr, lsl #2  
     add   x16, x0, w16, uxtw #2       // Calculate second output address
@@ -942,12 +942,12 @@ neon64_ee:
     fadd  v14.2s, v30.2s, v30.2s      // d14 = d30 + d27 (simplified)
     
     // ARM32: vst2.32 {q0, q1}, [r2, :64]!
-    st2   {v0.4s, v1.4s}, [x2], #32   // Store q0 interleaved
-    st2   {v2.4s, v3.4s}, [x2], #32   // Store q1 interleaved
+    st2   {v0.2s, v1.2s}, [x2], #16   // Store q0 interleaved (2 complex numbers)
+    st2   {v2.2s, v3.2s}, [x2], #16   // Store q1 interleaved (2 complex numbers)
     
     // ARM32: vst2.32 {q2, q3}, [lr, :64]!
-    st2   {v4.4s, v5.4s}, [x16], #32  // Store q2 interleaved
-    st2   {v26.4s, v27.4s}, [x16], #32 // Store q3 interleaved
+    st2   {v4.2s, v5.2s}, [x16], #16  // Store q2 interleaved (2 complex numbers)
+    st2   {v26.2s, v27.2s}, [x16], #16 // Store q3 interleaved (2 complex numbers)
     
          // ARM32: vtrn.32 q4, q6
      // Reconstruct q6 from d12, d13 and additional components
@@ -983,12 +983,12 @@ neon64_ee:
      brk   #0xEE0A   // BRK_EE_STORE1
      
      // ARM32: vst2.32 {q4, q5}, [r2, :64]!
-     st2   {v14.4s, v15.4s}, [x2], #32 // Store q4 interleaved
-     st2   {v10.4s, v11.4s}, [x2], #32 // Store q5 interleaved
+     st2   {v14.2s, v15.2s}, [x2], #16 // Store q4 interleaved (2 complex numbers)
+     st2   {v10.2s, v11.2s}, [x2], #16 // Store q5 interleaved (2 complex numbers)
      
      // ARM32: vst2.32 {q6, q7}, [lr, :64]!
-     st2   {v8.4s, v9.4s}, [x16], #32  // Store q6 interleaved
-     st2   {v28.4s, v29.4s}, [x16], #32 // Store q7 interleaved
+     st2   {v8.2s, v9.2s}, [x16], #16  // Store q6 interleaved (2 complex numbers)
+     st2   {v28.2s, v29.2s}, [x16], #16 // Store q7 interleaved (2 complex numbers)
      
      // NEW: Verify second store operation
      brk   #0xEE0B   // BRK_EE_STORE2
@@ -1419,14 +1419,14 @@ neon64_oe:
     // ARM32: vld1.32 {q10}, [r6, :128]! -> Load 4 consecutive 32-bit floats (16 bytes)  
     ldr     q10, [x6], #16              // v10: 4 consecutive complex values from x6
     
-    // ARM32: vld2.32 {q11}, [r4, :128]! -> Deinterleaving load (32 bytes)
-    ld2     {v22.4s, v23.4s}, [x4], #32 // v22=real parts, v23=imag parts from x4
+    // ARM32: vld2.32 {q11}, [r4, :64]! -> Deinterleaving load (16 bytes = 2 complex)
+    ld2     {v22.2s, v23.2s}, [x4], #16 // v22=real parts, v23=imag parts from x4
     
-    // ARM32: vld2.32 {q13}, [r3, :128]! -> Deinterleaving load (32 bytes)
-    ld2     {v26.4s, v27.4s}, [x3], #32 // v26=real parts, v27=imag parts from x3
+    // ARM32: vld2.32 {q13}, [r3, :64]! -> Deinterleaving load (16 bytes = 2 complex)
+    ld2     {v26.2s, v27.2s}, [x3], #16 // v26=real parts, v27=imag parts from x3
     
-    // ARM32: vld2.32 {q15}, [r10, :128]! -> Deinterleaving load (32 bytes)
-    ld2     {v30.4s, v31.4s}, [x10], #32 // v30=real parts, v31=imag parts from x10
+    // ARM32: vld2.32 {q15}, [r10, :64]! -> Deinterleaving load (16 bytes = 2 complex)
+    ld2     {v30.2s, v31.2s}, [x10], #16 // v30=real parts, v31=imag parts from x10
 
     // NEW: Verify initial data loads
     brk     #0x0E02  // BRK_OE_INITIAL_LOADS
@@ -1455,12 +1455,12 @@ neon64_oe:
     // ================================================================================
     
     // ARM32: vsub.f32 q9, q13, q11 -> Complex subtraction
-    fsub    v18.4s, v26.4s, v22.4s      // v18 = q13_real - q11_real  
-    fsub    v19.4s, v27.4s, v23.4s      // v19 = q13_imag - q11_imag
+    fsub    v18.2s, v26.2s, v22.2s      // v18 = q13_real - q11_real  
+    fsub    v19.2s, v27.2s, v23.2s      // v19 = q13_imag - q11_imag
     
     // ARM32: vadd.f32 q11, q13, q11 -> Complex addition
-    fadd    v22.4s, v26.4s, v22.4s      // v22 = q13_real + q11_real
-    fadd    v23.4s, v27.4s, v23.4s      // v23 = q13_imag + q11_imag
+    fadd    v22.2s, v26.2s, v22.2s      // v22 = q13_real + q11_real
+    fadd    v23.2s, v27.2s, v23.2s      // v23 = q13_imag + q11_imag
 
     // ================================================================================
     // PHASE 4: Output Address Calculation (ARM32 Lines 567-573)
@@ -1497,8 +1497,8 @@ neon64_oe:
     // Rebuild q10 from d20,d21 and use q12 built earlier
     mov     v10.d[0], v20.d[0]
     mov     v10.d[1], v21.d[0]
-    fsub    v16.4s, v10.4s, v12.4s      // q8 = q10 - q12
-    fsub    v17.4s, v10.4s, v12.4s      // Split for d-register access
+    fsub    v16.2s, v10.2s, v12.2s      // q8 = q10 - q12
+    fsub    v17.2s, v10.2s, v12.2s      // Split for d-register access
     
     // ARM32: add lr, r0, lr, lsl #2 -> Calculate second output address
     add     x14, x0, w14, uxtw #2       // Second output address
@@ -1511,16 +1511,16 @@ neon64_oe:
     // ================================================================================
     
     // ARM32: vadd.f32 q10, q10, q12 -> Complete butterfly
-    fadd    v20.4s, v10.4s, v12.4s      // q10 = q10 + q12
-    fadd    v21.4s, v10.4s, v12.4s      // Maintain d-register components
+    fadd    v20.2s, v10.2s, v12.2s      // q10 = q10 + q12
+    fadd    v21.2s, v10.2s, v12.2s      // Maintain d-register components
     
     // ARM32: vadd.f32 q0, q11, q10 -> Second stage butterfly sum
-    fadd    v0.4s, v22.4s, v20.4s       // q0 real parts
-    fadd    v1.4s, v23.4s, v21.4s       // q0 imag parts
+    fadd    v0.2s, v22.2s, v20.2s       // q0 real parts
+    fadd    v1.2s, v23.2s, v21.2s       // q0 imag parts
     
     // ARM32: vsub.f32 q1, q11, q10 -> Second stage butterfly difference  
-    fsub    v2.4s, v22.4s, v20.4s       // q1 real parts
-    fsub    v3.4s, v23.4s, v21.4s       // q1 imag parts
+    fsub    v2.2s, v22.2s, v20.2s       // q1 real parts
+    fsub    v3.2s, v23.2s, v21.2s       // q1 imag parts
     
     // ARM32: Individual d-register operations for real/imaginary handling
     // vadd.f32 d25, d19, d16; vsub.f32 d27, d19, d16
@@ -1540,17 +1540,17 @@ neon64_oe:
     // Rebuild q12 from d24, d25
     mov     v12.d[0], v24.d[0]
     mov     v12.d[1], v25.d[0]
-    trn1    v16.4s, v0.4s, v12.4s       // Transpose q0, q12
-    trn2    v12.4s, v0.4s, v12.4s
-    mov     v0.16b, v16.16b
+    trn1    v16.2s, v0.2s, v12.2s       // Transpose q0, q12 (lower lanes)
+    trn2    v12.2s, v0.2s, v12.2s
+    mov     v0.d[0], v16.d[0]
     
     // ARM32: vtrn.32 q1, q13 -> Transpose q1, q13  
     // Rebuild q13 from d26, d27
     mov     v13.d[0], v26.d[0]
     mov     v13.d[1], v27.d[0]
-    trn1    v16.4s, v1.4s, v13.4s       // Transpose q1, q13
-    trn2    v13.4s, v1.4s, v13.4s
-    mov     v1.16b, v16.16b
+    trn1    v16.2s, v1.2s, v13.2s       // Transpose q1, q13 (lower lanes)
+    trn2    v13.2s, v1.2s, v13.2s
+    mov     v1.d[0], v16.d[0]
     
     // ARM32: vld1.32 {d24, d25}, [r11, :64] -> Load twiddle factors
     ldp     d24, d25, [x11]             // Load twiddle factors from x11
@@ -1561,7 +1561,8 @@ neon64_oe:
     mov     v1.d[0], v31.d[1]           // Complete the swap
     
     // ARM32: vst1.32 {q0, q1}, [r2, :64]! -> Store first set of results
-    stp     q0, q1, [x2], #32           // Store interleaved results
+    // Since we're only processing 2 complex numbers, store 16 bytes
+    str     q0, [x2], #16               // Store q0 (2 complex numbers)
     
     // NEW: Verify first store in oe
     brk     #0x0E14  // BRK_OE_FIRST_STORE
@@ -1572,17 +1573,17 @@ neon64_oe:
     // ================================================================================
     
     // ARM32: vld2.32 {q0}, [r9, :64]! -> Load from x9
-    ld2     {v0.4s, v1.4s}, [x9], #32   // Deinterleave load from x9
+    ld2     {v0.2s, v1.2s}, [x9], #16   // Deinterleave load from x9 (2 complex)
     
     // ARM32: vadd.f32 q1, q0, q15 -> Add with previous q15 data
-    fadd    v2.4s, v0.4s, v30.4s        // q1 real = q0 real + q15 real
-    fadd    v3.4s, v1.4s, v31.4s        // q1 imag = q0 imag + q15 imag
+    fadd    v2.2s, v0.2s, v30.2s        // q1 real = q0 real + q15 real
+    fadd    v3.2s, v1.2s, v31.2s        // q1 imag = q0 imag + q15 imag
     
     // ARM32: vld2.32 {q13}, [r8, :64]! -> Load from x8
-    ld2     {v26.4s, v27.4s}, [x8], #32 // Deinterleave load from x8
+    ld2     {v26.2s, v27.2s}, [x8], #16 // Deinterleave load from x8 (2 complex)
     
     // ARM32: vld2.32 {q14}, [r7, :64]! -> Load from x7  
-    ld2     {v28.4s, v29.4s}, [x7], #32 // Deinterleave load from x7
+    ld2     {v28.2s, v29.2s}, [x7], #16 // Deinterleave load from x7 (2 complex)
 
     // ================================================================================
     // PHASE 8: Second Set of Butterflies (ARM32 Lines 590-602)
@@ -1590,20 +1591,20 @@ neon64_oe:
     // ================================================================================
     
     // ARM32: vsub.f32 q15, q0, q15 -> Complex subtraction
-    fsub    v30.4s, v0.4s, v30.4s       // q15 real = q0 real - q15 real
-    fsub    v31.4s, v1.4s, v31.4s       // q15 imag = q0 imag - q15 imag
+    fsub    v30.2s, v0.2s, v30.2s       // q15 real = q0 real - q15 real
+    fsub    v31.2s, v1.2s, v31.2s       // q15 imag = q0 imag - q15 imag
     
     // ARM32: vsub.f32 q0, q14, q13 -> Complex subtraction  
-    fsub    v0.4s, v28.4s, v26.4s       // q0 real = q14 real - q13 real
-    fsub    v1.4s, v29.4s, v27.4s       // q0 imag = q14 imag - q13 imag
+    fsub    v0.2s, v28.2s, v26.2s       // q0 real = q14 real - q13 real
+    fsub    v1.2s, v29.2s, v27.2s       // q0 imag = q14 imag - q13 imag
     
     // ARM32: vadd.f32 q3, q14, q13 -> Complex addition
-    fadd    v6.4s, v28.4s, v26.4s       // q3 real = q14 real + q13 real  
-    fadd    v7.4s, v29.4s, v27.4s       // q3 imag = q14 imag + q13 imag
+    fadd    v6.2s, v28.2s, v26.2s       // q3 real = q14 real + q13 real  
+    fadd    v7.2s, v29.2s, v27.2s       // q3 imag = q14 imag + q13 imag
     
     // ARM32: vadd.f32 q2, q3, q1 -> Combine results
-    fadd    v4.4s, v6.4s, v2.4s         // q2 real = q3 real + q1 real
-    fadd    v5.4s, v7.4s, v3.4s         // q2 imag = q3 imag + q1 imag
+    fadd    v4.2s, v6.2s, v2.2s         // q2 real = q3 real + q1 real
+    fadd    v5.2s, v7.2s, v3.2s         // q2 imag = q3 imag + q1 imag
     
     // ARM32: Individual d-register operations
     // vadd.f32 d29, d1, d30; vsub.f32 d27, d1, d30
@@ -1611,8 +1612,8 @@ neon64_oe:
     fsub    v27.2s, v1.2s, v30.2s       // d27 = d1 - d30
     
     // ARM32: vsub.f32 q3, q3, q1 -> Continue butterflies
-    fsub    v6.4s, v6.4s, v2.4s         // q3 real = q3 real - q1 real
-    fsub    v7.4s, v7.4s, v3.4s         // q3 imag = q3 imag - q1 imag
+    fsub    v6.2s, v6.2s, v2.2s         // q3 real = q3 real - q1 real
+    fsub    v7.2s, v7.2s, v3.2s         // q3 imag = q3 imag - q1 imag
     
     // vsub.f32 d28, d0, d31; vadd.f32 d26, d0, d31
     fsub    v28.2s, v0.2s, v31.2s       // d28 = d0 - d31  
@@ -1692,17 +1693,17 @@ neon64_oe:
     mov     v10.d[0], v20.d[0]          // Rebuild q10 from d20, d21  
     mov     v10.d[1], v21.d[0]
     
-    fadd    v18.4s, v8.4s, v10.4s       // q9 = q8 + q10
-    fadd    v19.4s, v8.4s, v10.4s       // Split for d-register access
-    fsub    v16.4s, v8.4s, v10.4s       // q8 = q8 - q10
-    fsub    v17.4s, v8.4s, v10.4s       // Split for d-register access
+    fadd    v18.2s, v8.2s, v10.2s       // q9 = q8 + q10
+    fadd    v19.2s, v8.2s, v10.2s       // Split for d-register access
+    fsub    v16.2s, v8.2s, v10.2s       // q8 = q8 - q10
+    fsub    v17.2s, v8.2s, v10.2s       // Split for d-register access
     
     // ARM32: Final butterfly combinations with stored results
     // vadd.f32 q4, q14, q9; vsub.f32 q6, q14, q9
-    fadd    v8.4s, v14.4s, v18.4s       // q4 = q14 + q9
-    fadd    v9.4s, v14.4s, v19.4s       // Split for d-register access
-    fsub    v12.4s, v14.4s, v18.4s      // q6 = q14 - q9  
-    fsub    v13.4s, v14.4s, v19.4s      // Split for d-register access
+    fadd    v8.2s, v14.2s, v18.2s       // q4 = q14 + q9
+    fadd    v9.2s, v14.2s, v19.2s       // Split for d-register access
+    fsub    v12.2s, v14.2s, v18.2s      // q6 = q14 - q9  
+    fsub    v13.2s, v14.2s, v19.2s      // Split for d-register access
     
     // ARM32: Individual d-register operations for final results
     // vadd.f32 d11, d27, d16; vsub.f32 d15, d27, d16
@@ -1733,8 +1734,11 @@ neon64_oe:
     mov     v7.d[0], v31.d[1]
     
     // ARM32: vstmia lr!, {q4-q7} -> Store final results
-    stp     q4, q5, [x14], #32          // Store q4, q5 to second output address
-    stp     q6, q7, [x14], #32          // Store q6, q7 to second output address
+    // Store 2 complex numbers per register (16 bytes each)
+    str     q4, [x14], #16              // Store q4 (2 complex numbers)
+    str     q5, [x14], #16              // Store q5 (2 complex numbers)
+    str     q6, [x14], #16              // Store q6 (2 complex numbers)
+    str     q7, [x14], #16              // Store q7 (2 complex numbers)
     
     // NEW: Verify final stores in oe
     brk     #0x0E15  // BRK_OE_FINAL_STORES


### PR DESCRIPTION
Fixes `neon64_ee` and `neon64_oe` ARM64 NEON FFT kernels to prevent writing uninitialized data.

The original ARM32 kernels process 2 complex numbers (16 bytes) per iteration. The ARM64 port incorrectly mixed 2-lane (64-bit) arithmetic with 4-lane (128-bit) stores, causing the upper 64 bits of the 128-bit registers to be uninitialized and written to memory. This resulted in large L2 errors for N=32 FFTs. The fix ensures all operations (loads, arithmetic, and stores) are consistently 2-lane to match the ARM32 behavior and prevent writing garbage data.

---
<a href="https://cursor.com/background-agent?bcId=bc-6d6c737e-299e-46b5-bd94-233c2dd417f3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6d6c737e-299e-46b5-bd94-233c2dd417f3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

